### PR TITLE
Upgrade to Alpine 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 MAINTAINER André Klitzing <aklitzing@gmail.com>
 
 ENV VERSION=1.22.2 QT_PLUGIN_PATH=/home/ausweisapp/libs/plugins


### PR DESCRIPTION
I'm using a new Radeon graphics card and the given radoen driver inside the docker container was failing to work with my newer X11 environment. After upgrading to Alpine 3.14, it just worked again.