### PR TITLE
fix: add linux/arm64 platform build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Hi, I wanted to run the image on macos M1, and I couldn't because linux/arm64 was missing. I've Added linux/arm64 in the build action. Hope it makes sense.